### PR TITLE
[Feature] Websocket Drowsiness Metrics

### DIFF
--- a/src/domain/dto/drowsiness_detection_result.py
+++ b/src/domain/dto/drowsiness_detection_result.py
@@ -19,3 +19,5 @@ class FaceDrowsinessState:
 @dataclass
 class DrowsinessDetectionResult:
     faces: List[FaceDrowsinessState] = field(default_factory=list)
+    drowsiness_event: Optional[str] = None
+    yawning_event: Optional[str] = None

--- a/src/domain/dto/drowsiness_event_metrics.py
+++ b/src/domain/dto/drowsiness_event_metrics.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DrowsinessEventMetrics(BaseModel):
+    drowsiness_event: Optional[str] = None
+    yawning_event: Optional[str] = None

--- a/src/domain/dto/facial_metrics.py
+++ b/src/domain/dto/facial_metrics.py
@@ -2,5 +2,7 @@ from pydantic import BaseModel
 
 
 class FacialMetrics(BaseModel):
-    ear : float
-    mar : float
+    ear : float = 0.0
+    mar : float = 0.0
+    is_drowsy : bool = False
+    is_yawning : bool = False

--- a/src/routers/drowsiness_realtime_router.py
+++ b/src/routers/drowsiness_realtime_router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
 
 from src.streaming.drowsiness_streaming import (
@@ -6,6 +8,7 @@ from src.streaming.drowsiness_streaming import (
     stream_raw_camera_feed,
 )
 from src.utils.frame_buffer import FrameBuffer
+from src.utils.logging import logging_default
 
 
 def drowsiness_realtime_router(frame_buffer : FrameBuffer):
@@ -32,4 +35,25 @@ def drowsiness_realtime_router(frame_buffer : FrameBuffer):
             stream_processed_drowsiness_feed(frame_buffer),
             media_type="multipart/x-mixed-replace; boundary=frame"
         )
+    
+    @router.websocket("/data/facialmetrics")
+    async def live_video_stream(websocket: WebSocket):
+        await websocket.accept()
+        try:
+            while True:
+                # Run the get_facial_metrics function in a non-blocking manner
+                facial_metrics = await asyncio.to_thread(frame_buffer.get_facial_metrics)
+
+                if facial_metrics:
+                    # Send the facial metrics as JSON if available
+                    await websocket.send_json(facial_metrics.model_dump_json())
+                else:
+                    # Default values if no metrics are available
+                    await websocket.send_json({"ear": 0.0, "mar": 0.0, "is_drowsy" : False, "is_calling" : "false"})
+
+        except WebSocketDisconnect:
+            logging_default.info("A client has been disconnected from WebSocket")
+
+
+
     return router

--- a/src/routers/drowsiness_realtime_router.py
+++ b/src/routers/drowsiness_realtime_router.py
@@ -39,6 +39,7 @@ def drowsiness_realtime_router(frame_buffer : FrameBuffer):
     @router.websocket("/data/facialmetrics")
     async def stream_facial_metrics_data(websocket: WebSocket):
         await websocket.accept()
+        logging_default.info("A client has been connected to WebSocket Facial Metrics")
         try:
             while True:
                 # Run the get_facial_metrics function in a non-blocking manner
@@ -58,9 +59,10 @@ def drowsiness_realtime_router(frame_buffer : FrameBuffer):
         except WebSocketDisconnect:
             logging_default.info("A client has been disconnected from WebSocket Facial Metrics")
     
-    @router.websocket("/notification/drowsiness/recent")
+    @router.websocket("/notification/drowsiness")
     async def stream_recent_drowsiness_data(websocket: WebSocket):
         await websocket.accept()
+        logging_default.info("A client has been connected to WebSocket Drowsiness Recent Event")
         try:
             while True:
                 # Run to get the recent drowsiness event happen in a non-blocking manner

--- a/src/services/drowsiness_detection_service.py
+++ b/src/services/drowsiness_detection_service.py
@@ -150,6 +150,8 @@ class DrowsinessDetectionService:
                     )
                     self.drowsiness_event_service.create_event(event)
                     self.drowsiness_notification_flag_sent = True
+                    detection_result.drowsiness_event = str(image_uuid)
+
             else:
                 if self.drowsiness_start_time is not None:
                     duration = time.time() - self.drowsiness_start_time
@@ -176,6 +178,7 @@ class DrowsinessDetectionService:
                     )
                     self.drowsiness_event_service.create_event(event)
                     self.yawning_notification_flag_sent = True
+                    detection_result.yawning_event = str(image_uuid)
             else:
                 self.yawning_notification_flag_sent = False
 

--- a/src/tasks/detection_task.py
+++ b/src/tasks/detection_task.py
@@ -125,6 +125,10 @@ class DetectionTask:
             else:
                 frame_buffer.update_facial_metrics(0, 0, False, False)
 
+            # Exposing recent detected event to websocket communication
+            if drowsiness_detection_result:
+                frame_buffer.update_drowsiness_event_recent(drowsiness_detection_result.drowsiness_event, drowsiness_detection_result.yawning_event)
+
             time.sleep(0.01)
 
     def draw_drowsiness_result(self, processed_frame, result : DrowsinessDetectionResult):

--- a/src/tasks/detection_task.py
+++ b/src/tasks/detection_task.py
@@ -118,6 +118,13 @@ class DetectionTask:
             # Save the processed 
             frame_buffer.update_processed(processed_frame)
 
+            # Exposing facial metrics to websocket communication
+            if drowsiness_detection_result.faces:
+                face = drowsiness_detection_result.faces[0]
+                frame_buffer.update_facial_metrics(face.ear, face.mar, face.is_drowsy, face.is_yawning)
+            else:
+                frame_buffer.update_facial_metrics(0, 0, False, False)
+
             time.sleep(0.01)
 
     def draw_drowsiness_result(self, processed_frame, result : DrowsinessDetectionResult):

--- a/src/utils/frame_buffer.py
+++ b/src/utils/frame_buffer.py
@@ -1,10 +1,16 @@
 from threading import Lock
+from typing import Optional
+
+import numpy as np
+
+from src.domain.dto.facial_metrics import FacialMetrics
 
 
 class FrameBuffer:
     def __init__(self):
-        self.raw_frame = None
-        self.processed_frame = None
+        self.raw_frame : np.ndarray = None
+        self.processed_frame : np.ndarray = None
+        self.facial_metrics: Optional[FacialMetrics] = None
         self.lock = Lock()
 
     def update_raw(self, frame):
@@ -26,3 +32,13 @@ class FrameBuffer:
         """Get the processed frame."""
         with self.lock:
             return self.processed_frame
+    
+    def update_facial_metrics(self, ear: float = 0.0, mar: float = 0.0, is_drowsy : bool = False, is_calling : bool = False):
+        """Update the EAR and MAR values using FacialMetrics class."""
+        with self.lock:
+            self.facial_metrics = FacialMetrics(ear=ear, mar=mar, is_drowsy=is_drowsy, is_calling=is_calling)
+
+    def get_facial_metrics(self) -> Optional[FacialMetrics]:
+        """Get the current FacialMetrics (EAR and MAR)."""
+        with self.lock:
+            return self.facial_metrics

--- a/src/utils/frame_buffer.py
+++ b/src/utils/frame_buffer.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from src.domain.dto.drowsiness_event_metrics import DrowsinessEventMetrics
 from src.domain.dto.facial_metrics import FacialMetrics
 
 
@@ -11,34 +12,49 @@ class FrameBuffer:
         self.raw_frame : np.ndarray = None
         self.processed_frame : np.ndarray = None
         self.facial_metrics: Optional[FacialMetrics] = None
-        self.lock = Lock()
+        self.drowsiness_event_metrics : Optional[DrowsinessEventMetrics] = None
+        
+        self.raw_lock = Lock()
+        self.processed_lock = Lock()
+        self.facial_metrics_lock = Lock()
+        self.drowsiness_event_lock = Lock()
 
     def update_raw(self, frame):
         """Update the raw frame."""
-        with self.lock:
+        with self.raw_lock:
             self.raw_frame = frame
 
     def get_raw(self):
         """Get the raw frame."""
-        with self.lock:
+        with self.raw_lock:
             return self.raw_frame
 
     def update_processed(self, frame):
         """Update the processed frame."""
-        with self.lock:
+        with self.processed_lock:
             self.processed_frame = frame
 
     def get_processed(self):
         """Get the processed frame."""
-        with self.lock:
+        with self.processed_lock:
             return self.processed_frame
+        
+    def update_drowsiness_event_recent(self, drowsiness_event : str, yawning_event : str):
+        """Update the recent detected of drowsiness and yawning event"""
+        with self.drowsiness_event_lock:
+            self.drowsiness_event_metrics = DrowsinessEventMetrics(drowsiness_event=drowsiness_event, yawning_event=yawning_event)
     
+    def get_drowsiness_event_recent(self) -> Optional[DrowsinessEventMetrics]:
+        """Get the current recent event detected"""
+        with self.drowsiness_event_lock:
+            return self.drowsiness_event_metrics
+
     def update_facial_metrics(self, ear: float = 0.0, mar: float = 0.0, is_drowsy : bool = False, is_calling : bool = False):
         """Update the EAR and MAR values using FacialMetrics class."""
-        with self.lock:
+        with self.facial_metrics_lock:
             self.facial_metrics = FacialMetrics(ear=ear, mar=mar, is_drowsy=is_drowsy, is_calling=is_calling)
 
     def get_facial_metrics(self) -> Optional[FacialMetrics]:
         """Get the current FacialMetrics (EAR and MAR)."""
-        with self.lock:
+        with self.facial_metrics_lock:
             return self.facial_metrics


### PR DESCRIPTION
In this PR, I have added some feature which is exposing real-time data drowsiness metrics into the Event Driven API, where this is a preparation for building the internal dashboard that will need these drowsiness metrics.

Specifically, I implemented two WebSocket endpoints
- ws://realtime/data/facialmetrics
- ws://realtime/notification/drowsiness

During development, I identified a timing discrepancy issue between the detection loop (which updates the shared frame buffer) and the WebSocket streaming loop (which reads from the buffer). Because the detection loop has a small time.sleep delay, the WebSocket loop was repeatedly reading the same data before the detection loop could update it, resulting in duplicate or stale data being sent.

To address this, I introduced a synchronization mechanism by resetting the event data in the buffer after it is consumed by the WebSocket. This ensures that the clients receive fresh events only once per detection update, reducing redundant messages and improving the accuracy of real-time streaming. As on the facial metrics, I just hack for now by adding sleep thread into the websocket.

Additionally, I refactored and shortened the WebSocket route paths to make the API cleaner and easier to consume by clients.